### PR TITLE
fixes #2 (template with same name as existing module) and add option to set template extension

### DIFF
--- a/demo/foo/test_path.hbs
+++ b/demo/foo/test_path.hbs
@@ -1,0 +1,1 @@
+<p>This partial has the same name as the module that loads it! Which is: <strong>{{name}}</strong></p>

--- a/demo/foo/test_path.js
+++ b/demo/foo/test_path.js
@@ -1,0 +1,8 @@
+define(['hbs!./test_path'], function (template) {
+
+  var container = document.createElement('div');
+  //innerHtml is evil! don't use it on a node with child elements.
+  container.innerHTML += template({'name' : 'testpath'});
+  document.body.appendChild(container);
+
+});

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,7 +1,10 @@
 // Require our template with the handlebars plugin
-define('main',['require', 'hbs'], function (require, hbs) {
+define('main',['require', 'hbs', './foo/test_path'], function (require, hbs) {
 
   //allow customization without editing shource
+  //note that further hbs! requires/defines will load files with .handlebars
+  //extension, beware that it may break things badly, use it with care and only
+  //before loading other templates...
   hbs.setExtension('.handlebars');
 
   require(['hbs!template/one'], function(tmplOne){

--- a/hbs.js
+++ b/hbs.js
@@ -81,7 +81,7 @@ define('hbs', ['Handlebars'], function ( Handlebars ) {
             }
             reader.close();
             callback(text);
-        }
+        };
     }
 
       return {
@@ -106,7 +106,7 @@ define('hbs', ['Handlebars'], function ( Handlebars ) {
         load: function (name, parentRequire, load, config) {
             var partialDeps = [];
             function findPartialDeps( text ) {
-              var matches = text.match( /{{>\s*([^\s]+?)\s*}}/ig );
+              var matches = text.match( /\{\{>\s*([^\s]+?)\s*\}\}/ig );
               var res = [];
               for (var i in matches) {
                 res.push(matches[i].split(' ')[1]);
@@ -124,7 +124,7 @@ define('hbs', ['Handlebars'], function ( Handlebars ) {
                 }
 
                 var prec = Handlebars.precompile(text);
-                text = "/* START_TEMPLATE */\n" + 
+                text = "/* START_TEMPLATE */\n" +
                        "define('hbs!"+name+"',['hbs','Handlebars'"+depStr+"], function( hbs, Handlebars ){ \n" +
                          "var t = Handlebars.template(" + prec + ");\n" +
                          "Handlebars.registerPartial('" + name.replace( /\//g , '_') + "', t);\n" +
@@ -153,23 +153,23 @@ define('hbs', ['Handlebars'], function ( Handlebars ) {
 
                 if ( !config.isBuild ) {
                   require( deps, function (){
-                    load.fromText(name, text);
+                    load.fromText(path, text);
 
                     //Give result to load. Need to wait until the module
                     //is fully parse, which will happen after this
                     //execution.
-                    parentRequire([name], function (value) {
+                    parentRequire([path], function (value) {
                       load(value);
                     });
                   });
                 }
                 else {
-                  load.fromText(name, text);
+                  load.fromText(path, text);
 
                   //Give result to load. Need to wait until the module
                   //is fully parse, which will happen after this
                   //execution.
-                  parentRequire([name], function (value) {
+                  parentRequire([path], function (value) {
                     load(value);
                   });
                 }


### PR DESCRIPTION
added a method `setExtension()` to the plugin so we don't need to edit the plugin to change the extension.. it is important to notice that it will affect all further requests so it should be called at the top level require and used with care. (the main thing was to move the extension to the top and change the default value to '.hbs')

see #2
