### PR TITLE
Remove Handlebars.Parser after build.

### DIFF
--- a/Handlebars.js
+++ b/Handlebars.js
@@ -93,7 +93,7 @@ Handlebars.registerHelper('log', function(context) {
 });
 ;
 
-//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+//>>excludeStart('excludeHbsParser', pragmas.excludeHbsParser)
 // no need for parser if templates are pre-compiled
 
 // lib/handlebars/compiler/parser.js
@@ -565,7 +565,7 @@ Handlebars.parse = function(string) {
   Handlebars.Parser.yy = Handlebars.AST;
   return Handlebars.Parser.parse(string);
 };
-//>>excludeEnd('excludeAfterBuild')
+//>>excludeEnd('excludeHbsParser')
 
 
 Handlebars.print = function(ast) {

--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -8,8 +8,11 @@
     // inlining ftw
     inlineText: true,
 
-    // kills the entire plugin set once it's built.
     pragmasOnSave: {
+        //removes Handlebars.Parser code (used to compile template strings)
+        //set it to `false` if you need template strings even after build
+        excludeHbsParser : true,
+        // kills the entire plugin set once it's built.
         excludeAfterBuild: true
     },
 


### PR DESCRIPTION
There is no need to keep the parser since templates are precompiled.
The parser code is actually pretty big (1/3) of handlebars file size
and since we remove the plugin code we should do the same on what isn't
needed.
