### PR TITLE
Rename excludeAfterBuild pragma.

### DIFF
--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -13,7 +13,7 @@
         //set it to `false` if you need template strings even after build
         excludeHbsParser : true,
         // kills the entire plugin set once it's built.
-        excludeAfterBuild: true
+        excludeHbs: true
     },
 
     paths: {

--- a/hbs.js
+++ b/hbs.js
@@ -10,18 +10,18 @@
 /*global require: false, XMLHttpRequest: false, ActiveXObject: false,
 define: false, process: false, window: false */  
 define([
-//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+//>>excludeStart('excludeHbs', pragmas.excludeHbs)
 'Handlebars', 'underscore', 'Handlebars/i18nprecompile', 'json2'
-//>>excludeEnd('excludeAfterBuild')
+//>>excludeEnd('excludeHbs')
 ], function (
-//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+//>>excludeStart('excludeHbs', pragmas.excludeHbs)
  Handlebars, _, precompile, JSON
-//>>excludeEnd('excludeAfterBuild')
+//>>excludeEnd('excludeHbs')
 ) {
 // NOTE :: if you want to load template in production outside of the build, either precompile
 // them into modules or take out the conditional build stuff here
 
-//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+//>>excludeStart('excludeHbs', pragmas.excludeHbs)
   var fs, getXhr,
         progIds = ['Msxml2.XMLHTTP', 'Microsoft.XMLHTTP', 'Msxml2.XMLHTTP.4.0'],
         fetchText = function () {
@@ -112,7 +112,7 @@ define([
       }
     };
     var styleList = [], styleMap = {};
-//>>excludeEnd('excludeAfterBuild')
+//>>excludeEnd('excludeHbs')
 
       return {
 
@@ -135,7 +135,7 @@ define([
         version: '1.0.3beta',
 
         load: function (name, parentRequire, load, config) {
-          //>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+          //>>excludeStart('excludeHbs', pragmas.excludeHbs)
             
 
             var compiledName = name + customNameExtension,
@@ -419,7 +419,7 @@ define([
                   }
               });
             });
-          //>>excludeEnd('excludeAfterBuild')
+          //>>excludeEnd('excludeHbs')
         }
       };
 });


### PR DESCRIPTION
It's a better idea to have something unique, that way it will avoid
conflicts with other plugins/modules and user will have granular
control of what he wants to exclude.
