### PR TITLE
Added helper path callback option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ require(['template/helpers/roundNumber'], function ( roundNumber ){
 
 It's just a module that happens to register itself.
 
+You can specify a helper path callback in the config. The callback should be a function that gets a name of a helper as the only argument and returns the full path to be `require()`-d, e.g., the following callback allows for automatic loading of helper modules written in CoffeeScript (via the require-cs plugin) under a non-standard location:
+
+```javascript
+require({
+  hbs : {
+    helperPathCallback: function(name) {return 'cs!/helpers/' + name;}
+  }
+}, ['main'])
+```
 
 # Meta Data
 

--- a/hbs.js
+++ b/hbs.js
@@ -287,7 +287,17 @@ define([
                       vars = extDeps.vars,
                       helps = extDeps.helpers || [],
                       depStr = deps.join("', 'hbs!").replace(/_/g, '/'),
-                      helpDepStr = helps.join("', 'template/helpers/"),
+                      helpDepStr = (function (){
+                        var i, paths = [],
+                            pathGetter = config.hbs && config.hbs.helperPathCallback
+                              ? config.hbs.helperPathCallback
+                              : function (name){return 'template/helpers/' + name;};
+
+                        for ( i = 0; i < helps.length; i++ ) {
+                          paths[i] = "'" + pathGetter(helps[i]) + "'"
+                        }
+                        return paths;
+                      })().join(','),
                       debugOutputStart = "",
                       debugOutputEnd   = "",
                       debugProperties = "",
@@ -298,7 +308,7 @@ define([
                     depStr = ",'hbs!" + depStr + "'";
                   }
                   if ( helpDepStr ) {
-                    helpDepStr = ",'template/helpers/" + helpDepStr + "'";
+                    helpDepStr = "," + helpDepStr;
                   }
 
                   


### PR DESCRIPTION
Example: The following callback allows for automatic loading of helper modules written in CoffeeScript (compiled on-the-fly via the require-cs plugin) under a non-standard location:

```
require({
  hbs : {
    helperPathCallback: function(name) {return 'cs!/helpers/' + name;}
  }
}, ['main']);
```

The default behavior remains unchanged.
