### PR TITLE
changing default config to exclude i18n precompiler and underscore on build

### DIFF
--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -13,7 +13,9 @@
         //set it to `false` if you need template strings even after build
         excludeHbsParser : true,
         // kills the entire plugin set once it's built.
-        excludeHbs: true
+        excludeHbs: true,
+        //removes i18n precompiler
+        excludeAfterBuild: true
     },
 
     paths: {
@@ -28,6 +30,11 @@
         //included already in require-jquery.js
         {
             name: "main",
+
+            //the hbs plugin requires underscore
+            //the only way to remove it after build is to manually exclude it
+            //if you require underscore, comment out this line
+            exclude: ['underscore']
         }
     ]
 })


### PR DESCRIPTION
I added a pragma and a manual module exclude to get some of the dev and build dependencies out of my final main.js file.

To get all of the modules that depended on underscore out of my build, I had to add `excludeAfterBuild: true` to the `pragmasOnSave` property in app.build.js. At this point, there were no modules that depeneded on underscore within my final built main.js, however underscore was still being included. To finally exclude underscore, I had to add `exclude: ['underscore']` to my main.js module config within app.build.js.

This works for my setup, but not really sure if this will bust the handlebars plugin for other use cases.

Thoughts?
