### PR TITLE
Plugin chokes when executing under Node with jsDom

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -32,7 +32,7 @@ define([
         buildStyleDirectory = "/demo-build/styles/",
         buildCSSFileName = "screen.build.css";
 
-    if (typeof window !== "undefined" && window.navigator && window.document) {
+    if (typeof window !== "undefined" && window.navigator && window.document && !window.navigator.userAgent.match(/Node.js/)) {
         // Browser action
         getXhr = function () {
             //Would love to dump the ActiveX crap in here. Need IE 6 to die first.


### PR DESCRIPTION
The current 'is a browser' conditional passes when jsDom is used to add a global window object even though it's executing under Node.js.

This adds another condition to that test to ensure that 'Node.js' is not present in the user agent string.
