### PR TITLE
Move all the dependencies to the hbs folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ As long as all of your paths match up, this should precompile all of your templa
 
 ## So many dependencies in the `hbs` plugin!
 
-I use them for coding happiness. It shouldn't bother you tooooo much, because it all gets built out in production. The `hbs.js` file essentially gets written to the main.js file as a noop (a few empty definitions), and none of it's dependencies are included into the build.
+I use them for coding happiness. It shouldn't bother you tooooo much, because it all gets built out in production. The `hbs.js` file essentially gets written to the main.js file as a noop (a few empty definitions), and none of it's dependencies are included into the build. All the dependencies are inside the `hbs` folder and this folder should be a sibling of the `hbs.js` file.
 
 # Demo
 

--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -4,37 +4,34 @@
     dir: "../demo-build",
 
     optimizeCss: "standard",
-    //optimize: "none",
+    // optimize: "none",
     // inlining ftw
     inlineText: true,
 
     pragmasOnSave: {
-        //removes Handlebars.Parser code (used to compile template strings)
-        //set it to `false` if you need template strings even after build
+        //removes Handlebars.Parser code (used to compile template strings) set
+        //it to `false` if you need to parse template strings even after build
         excludeHbsParser : true,
         // kills the entire plugin set once it's built.
         excludeHbs: true,
-        //removes i18n precompiler
+        // removes i18n precompiler, handlebars and json2
         excludeAfterBuild: true
     },
 
     paths: {
       "hbs": "../hbs",
       "Handlebars" : "../Handlebars"
+      // if your project is already using underscore.js and you want to keep
+      // the hbs plugin even after build (excludeHbs:false) you should set the
+      // "hbs/underscore" path to point to the shared location like
+      // "hbs/underscore" : "lib/undescore" to avoid loading it twice
     },
 
     locale: "en_ca",
 
     modules: [
-        //Optimize the application files. Exclude jQuery since it is
-        //included already in require-jquery.js
         {
-            name: "main",
-
-            //the hbs plugin requires underscore
-            //the only way to remove it after build is to manually exclude it
-            //if you require underscore, comment out this line
-            exclude: ['underscore']
+            name: "main"
         }
     ]
 })

--- a/hbs.js
+++ b/hbs.js
@@ -11,7 +11,7 @@
 define: false, process: false, window: false */  
 define([
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
-'Handlebars', 'underscore', 'Handlebars/i18nprecompile', 'json2'
+'Handlebars', './hbs/underscore', './hbs/i18nprecompile', './hbs/json2'
 //>>excludeEnd('excludeHbs')
 ], function (
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)

--- a/hbs/i18nprecompile.js
+++ b/hbs/i18nprecompile.js
@@ -1,5 +1,5 @@
 //>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
-define(['Handlebars', "underscore"], function ( Handlebars, _ ) {
+define(['Handlebars', "./underscore"], function ( Handlebars, _ ) {
 
   function replaceLocaleStrings ( ast, mapping ) {
     mapping = mapping || {};

--- a/hbs/json2.js
+++ b/hbs/json2.js
@@ -1,3 +1,4 @@
+//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
 /*
     http://www.JSON.org/json2.js
     2011-10-19
@@ -361,3 +362,4 @@ define(function(){
 // otherwise just leave it alone
     
 }).call(this, this);
+//>>excludeEnd('excludeAfterBuild')

--- a/hbs/underscore.js
+++ b/hbs/underscore.js
@@ -1,3 +1,5 @@
+//>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
+
 //     Underscore.js 1.3.1
 //     (c) 2009-2012 Jeremy Ashkenas, DocumentCloud Inc.
 //     Underscore is freely distributable under the MIT license.
@@ -999,10 +1001,14 @@
 
   // AMD define happens at the end for compatibility with AMD loaders
   // that don't enforce next-turn semantics on modules.
+  // ----
+  // define as unnamed module so it can be easily removed after build
+  // without affecting other modules
   if (typeof define === 'function' && define.amd) {
-    define('underscore', function() {
+    define(function() {
       return _;
     });
   }
 
 }).call(this);
+//>>excludeEnd('excludeAfterBuild')


### PR DESCRIPTION
I'm not using underscore.js on my projects and I would like to keep all the dependencies referent to RequireJS plugins inside a `js/lib/require` folder for organization purposes.

I'm afraid that other devs might just assume underscore is available and start using it for tasks that are already available on another lib used by the app (I use [amd-utils](http://millermedeiros.github.com/amd-utils/) on almost all projects).

The only drawback of this change is that user need to be aware that he might end up with 2 versions of underscore.js if he uses the wrong build settings (excludeHbs:false, excludeAfterBuild:false) while using underscore.js in another part of the app (see comment at the end of build settings).

I've been using this approach in the past couple projects, just didn't had time to ask for the pull request.
