### PR TITLE
Add option to disable looking for helpers

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -289,7 +289,8 @@ define([
                       vars = extDeps.vars,
                       helps = extDeps.helpers || [],
                       depStr = deps.join("', 'hbs!").replace(/_/g, '/'),
-                      helpDepStr = (function (){
+                      helpDepStr = config.hbs && config.hbs.disableHelpers ?
+                      "" : (function (){
                         var i, paths = [],
                             pathGetter = config.hbs && config.hbs.helperPathCallback
                               ? config.hbs.helperPathCallback


### PR DESCRIPTION
Configure as follows:

```
hbs: {
  disableHelpers: true
}
```

This is useful for when you want to use helpers attached to
Handlebars elsewhere (which will error, as it will try to
load a module which doesn't exist).
