### PR TITLE
Make i18n work with inverse blocks

### DIFF
--- a/hbs/i18nprecompile.js
+++ b/hbs/i18nprecompile.js
@@ -20,6 +20,10 @@ define(['Handlebars', "./underscore"], function ( Handlebars, _ ) {
           statement.program = replaceLocaleStrings( statement.program, mapping );
         }
       });
+      // Also cover the else blocks
+      if (ast.inverse) {
+        replaceLocaleStrings(ast.inverse, mapping);
+      }
     }
     return ast;
   }


### PR DESCRIPTION
Currently, template in the form
{{#if condition}}
{{else}}
  {{$ "i18nstr"}}
{{/if}}

will not work.  This fixes it (issue #32).
