### PR TITLE
Changing defines to use canonical names instead of relative file paths.

### DIFF
--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -20,7 +20,10 @@
 
     paths: {
       "hbs": "../hbs",
-      "Handlebars" : "../Handlebars"
+      "handlebars" : "../Handlebars",
+      "underscore" : "../hbs/underscore",
+      "i18nprecompile" : "../hbs/i18nprecompile",
+      "json2" : "../hbs/json2",
       // if your project is already using underscore.js and you want to keep
       // the hbs plugin even after build (excludeHbs:false) you should set the
       // "hbs/underscore" path to point to the shared location like

--- a/hbs.js
+++ b/hbs.js
@@ -11,7 +11,7 @@
 define: false, process: false, window: false */  
 define([
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
-'Handlebars', './hbs/underscore', './hbs/i18nprecompile', './hbs/json2'
+'handlebars', 'underscore', 'i18nprecompile', 'json2'
 //>>excludeEnd('excludeHbs')
 ], function (
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
@@ -380,7 +380,7 @@ define([
                       prec = precompile( text, mapping, { originalKeyFallback: (config.hbs || {}).originalKeyFallback });
 
                   text = "/* START_TEMPLATE */\n" +
-                         "define(['hbs','Handlebars'"+depStr+helpDepStr+"], function( hbs, Handlebars ){ \n" +
+                         "define(['hbs','handlebars'"+depStr+helpDepStr+"], function( hbs, Handlebars ){ \n" +
                            "var t = Handlebars.template(" + prec + ");\n" +
                            "Handlebars.registerPartial('" + name.replace( /\//g , '_') + "', t);\n" +
                            debugProperties +

--- a/hbs/i18nprecompile.js
+++ b/hbs/i18nprecompile.js
@@ -1,5 +1,5 @@
 //>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
-define(['Handlebars', "./underscore"], function ( Handlebars, _ ) {
+define(['handlebars', "underscore"], function ( Handlebars, _ ) {
 
   function replaceLocaleStrings ( ast, mapping, options ) {
     options = options || {};


### PR DESCRIPTION
Nice work on the require plugin. Just a small fix that would improve portability and re-usability significantly.

Allows the using application to define where the libraries are, what the file names are, whether to wrap in a module, etc. Separation of concerns is a good thing.
