### PR TITLE
Make sure to remove BOM from file on compile

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -80,8 +80,11 @@ define([
                !!process.versions.node) {
         //Using special require.nodeRequire, something added by r.js.
         fs = require.nodeRequire('fs');
-        fetchText = function (path, callback) {
-            callback(fs.readFileSync(path, 'utf8'));
+        fetchText = function ( path, callback ) {
+            var body = fs.readFileSync(path, 'utf8') || "";
+            // we need to remove BOM stuff from the file content
+            body = body.replace(/^\uFEFF/, '');
+            callback(body);
         };
     } else if (typeof java !== "undefined" && typeof java.io !== "undefined") {
         fetchText = function(path, callback) {


### PR DESCRIPTION
Whenever hbs is creating pre-compiled templates, we need to make sure the BOM (UTF-8 header) is removed or it'll create weird strings in templates that pushes content around.

This will also fix edge-cases were readFileSync will not return a string if file wasn't found.

See https://github.com/joyent/node/issues/1918 for the work-around used.
