### PR TITLE
Add rudimentary support for `removeCombined`.

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -432,6 +432,10 @@ define([
                       load(value);
                     });
                   }
+
+                  if ( config.removeCombined ) {
+                    fs.unlinkSync(path);
+                  }
               });
             }
 


### PR DESCRIPTION
This will add very basic support for removing the templates when they're compiled into the build, I thought it would compliment `r.js`'s `removeCombined` option pretty well.

I haven't tested this thoroughly but it seems to work OK in another project (and also in the demo app in this repo).
