### PR TITLE
Add Compile Options in config.hbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Then visit `http://127.0.0.1:8000/demo.html` for the dev version.
 
 And visit `http://127.0.0.1:8000/demo-build.html` for the production build version.
 
-You should be able to see all of the templates and individual files in your network panel in dev mode, and just 2 minified files in build mode. 
+You should be able to see all of the templates and individual files in your network panel in dev mode, and just 2 minified files in build mode.
 
 # Config
 
@@ -247,6 +247,8 @@ require.config({
 
     templateExtension: "html" // Set the extension automatically appended to templates
                               // ('hbs' by default)
+
+    compileOptions: {}        // options object which is passed to Handlebars compiler
   }
 
 })
@@ -256,7 +258,7 @@ require.config({
 
 ## Partial Collision
 
-This plugin registers every single template as a partial with it's modified module name (Slashes replaced with underscores, and no file extension). 
+This plugin registers every single template as a partial with it's modified module name (Slashes replaced with underscores, and no file extension).
 
 `App/Template/One.handlebars` is registered as `App_Template_One`
 

--- a/hbs.js
+++ b/hbs.js
@@ -383,7 +383,9 @@ define([
                   }
 
                   var mapping = disableI18n? false : _.extend( langMap, config.localeMapping ),
-                      prec = precompile( text, mapping, { originalKeyFallback: (config.hbs || {}).originalKeyFallback });
+                      configHbs = config.hbs || {},
+                      options = _.extend(configHbs.compileOptions || {}, { originalKeyFallback: configHbs.originalKeyFallback }),
+                      prec = precompile( text, mapping, options);
 
                   text = "/* START_TEMPLATE */\n" +
                          "define(['hbs','handlebars'"+depStr+helpDepStr+"], function( hbs, Handlebars ){ \n" +


### PR DESCRIPTION
As there is currently no way to specify Handlebars compile options, I've added a compileOptions property to the config object which is passed to Handlebars when compiling a template.

This is useful when you need to specify options such as data = true:

``` javascript
compileOptions: {
   data: true
}
```
