### PR TITLE
Allow template files to pass through with their own extension

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -444,7 +444,13 @@ define([
               });
             }
 
-            var path = parentRequire.toUrl(name +'.'+ (config.hbs && config.hbs.templateExtension? config.hbs.templateExtension : templateExtension));
+            var path,
+                omitExtension = config.hbs && config.hbs.templateExtension === false;
+            if(omitExtension) {
+              path = parentRequire.toUrl(name);
+            } else {
+              path = parentRequire.toUrl(name +'.'+ (config.hbs && config.hbs.templateExtension ? config.hbs.templateExtension : templateExtension));
+            }
 
             if (disableI18n){
                 fetchAndRegister(false);


### PR DESCRIPTION
Thanks for the great plugin!

I keep my views in the same folder as my templates, only differing by extension.
e.g.
`views/calendar.js`
`views/calendar.hbs`

It's convenient to have the view and templates in the same folder. However there seems to be a RequireJS path conflict when templates don't have an extension in their url--unable to differentiate between the view and the template.

> Error in the browser:
>     Uncaught Error: Load timeout for modules: 
> hbs!views/calendar/calendar_unnormalized3,hbs!views/calendar/calendar

Error during build:

> Error: Loader plugin did not call the load callback in the build: hbs 
> Module loading did not complete for: main, app
> ...
> views/calendar/calendar, hbs!views/calendar/calendar,
> The following modules share the same URL. This could be a misconfiguration if
> that URL only has one anonymous module in it:
> undefined: hbs!views/calendar/calendar
> at Function.build.traceDependencies
> (/.../requirejs/bin/r.js:15178:19)

Relevant section of `calendar.js`

```
define(function(require) {
    var Backbone = require('backbone'),
        mainTemplate = require('hbs!views/calendar/calendar');

    return Backbone.View.extend({
        events: {}
        ...

        render: function(){
            this.mainTemplate(this.model.toJSON());
            return this;
        }
    });
});
```

This PR is one way to resolve the issue. It allows template file extensions to pass through, resulting in a different path than the view file. It re-uses the config.templateExtension setting:

```
hbs: {
    templateExtension: false
}
```

Another approach to resolving this issue would be swell too. Thanks.
