### PR TITLE
fixed #69 - breaks when used under nodejs / r.js optimizer as it was not...

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -428,7 +428,7 @@ define([
                     });
                   }
                   else {
-                    load.fromText(text);
+                    load.fromText(name, text);
 
                     //Give result to load. Need to wait until the module
                     //is fully parse, which will happen after this


### PR DESCRIPTION
... storing name of module and subsequent request was looking for resource.js and not resource.hbs
