### PR TITLE
Allow helper callback to use template path

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -309,7 +309,7 @@ define([
                               : function (name){return (config.hbs && config.hbs.helperDirectory ? config.hbs.helperDirectory : helperDirectory) + name;};
 
                         for ( i = 0; i < helps.length; i++ ) {
-                          paths[i] = "'" + pathGetter(helps[i]) + "'"
+                          paths[i] = "'" + pathGetter(helps[i], path) + "'"
                         }
                         return paths;
                       })().join(','),


### PR DESCRIPTION
This allows you to base the location of the helpers on the template file, in case they are relative to the template / there are multiple helper locations, etc.
