### PR TITLE
Fix IE incompatibility

### DIFF
--- a/Handlebars.js
+++ b/Handlebars.js
@@ -839,7 +839,7 @@ Handlebars.Utils = {
   isEmpty: function(value) {
     if (!value && value !== 0) {
       return true;
-    } else if(toString.call(value) === "[object Array]" && value.length === 0) {
+    } else if(Object.prototype.toString.call(value) === "[object Array]" && value.length === 0) {
       return true;
     } else {
       return false;


### PR DESCRIPTION
Handlebars now aliases toString as Object.prototype.toString, but
due to the way we wrap the individual parts of Handlebars, when
executing isEmpty IE will use the window scope for toString. This
makes the reference explicit.
