### PR TITLE
handlebar -> Handlebar 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Then in your templates, you can just do:
 The system will make sure these modules are pulled in automatically from that directory. But if in your app, you need a rounding module (perhaps in a view/datanormalization place), you could do this:
 
 ```javascript
-require(['template/helpers/roundNumber'], function ( roundNumber ){
+require(['template/helpers/roundNumber'], function ( roundNumber ) {
   var threeFourths = (3/4);
   alert( roundNumber( threeFourths ));
 });

--- a/demo.html
+++ b/demo.html
@@ -22,7 +22,7 @@
   // Essentially just ignore this.
   paths  : {
     'hbs' : '../hbs',
-    'handlebars' : '../Handlebars',
+    'Handlebars' : '../Handlebars',
     'underscore' : '../hbs/underscore',
     'i18nprecompile' : '../hbs/i18nprecompile',
     'json2' : '../hbs/json2'

--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -20,7 +20,7 @@
 
     paths: {
       "hbs": "../hbs",
-      "handlebars" : "../Handlebars",
+      "Handlebars" : "../Handlebars",
       "underscore" : "../hbs/underscore",
       "i18nprecompile" : "../hbs/i18nprecompile",
       "json2" : "../hbs/json2"

--- a/demo/template/helpers/yeller.js
+++ b/demo/template/helpers/yeller.js
@@ -1,4 +1,4 @@
-define(['handlebars'], function ( Handlebars ){
+define(['Handlebars'], function ( Handlebars ){
   function yeller ( context, options ) {
     // Assume it's a string for simplicity.
     return context + "!!!!!!oneone!!one1";

--- a/hbs.js
+++ b/hbs.js
@@ -1,5 +1,5 @@
 /**
- * @license handlebars hbs 0.4.0 - Alex Sexton, but Handlebars has it's own licensing junk
+ * @license Handlebars hbs 0.4.0 - Alex Sexton, but Handlebars has it's own licensing junk
  *
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/require-cs for details on the plugin this was based off of
@@ -11,7 +11,7 @@
 define: false, process: false, window: false */
 define([
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
-'./handlebars', './hbs/underscore', './hbs/i18nprecompile', './hbs/json2'
+'./Handlebars', './hbs/underscore', './hbs/i18nprecompile', './hbs/json2'
 //>>excludeEnd('excludeHbs')
 ], function (
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
@@ -231,8 +231,8 @@ define([
                   // grab the params
                   if ( statement.params && typeof Handlebars.helpers[statement.id.string] === 'undefined') {
                     _(statement.params).forEach(function(param) {
-                      if ( _(paramsWithoutParts).contains(param.original) 
-                         || param instanceof Handlebars.AST.StringNode 
+                      if ( _(paramsWithoutParts).contains(param.original)
+                         || param instanceof Handlebars.AST.StringNode
                         || param instanceof Handlebars.AST.IntegerNode
                         || param instanceof Handlebars.AST.BooleanNode
                         ) {
@@ -396,7 +396,7 @@ define([
                       prec = precompile( text, mapping, options);
 
                   text = "/* START_TEMPLATE */\n" +
-                         "define(['hbs','handlebars'"+depStr+helpDepStr+"], function( hbs, Handlebars ){ \n" +
+                         "define(['hbs','Handlebars'"+depStr+helpDepStr+"], function( hbs, Handlebars ){ \n" +
                            "var t = Handlebars.template(" + prec + ");\n" +
                            "Handlebars.registerPartial('" + name.replace( /\//g , '_') + "', t);\n" +
                            debugProperties +
@@ -478,7 +478,7 @@ define([
                 		fetchAndRegister(false);
                 	} else {
                 		throw er;
-                	
+
                 	}
                 }
             }

--- a/hbs/i18nprecompile.js
+++ b/hbs/i18nprecompile.js
@@ -1,5 +1,5 @@
 //>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
-define(['../handlebars', "./underscore"], function ( Handlebars, _ ) {
+define(['../Handlebars', "./underscore"], function ( Handlebars, _ ) {
 
   function replaceLocaleStrings ( ast, mapping, options ) {
     options = options || {};
@@ -9,7 +9,7 @@ define(['../handlebars', "./underscore"], function ( Handlebars, _ ) {
       _(ast.statements).forEach(function(statement, i){
         var newString = "<!-- i18n error -->";
         // If it's a translation node
-        if ( statement.type == "mustache" && statement.id && statement.id.original == "$" ) {
+        if ( statement.type === "mustache" && statement.id && statement.id.original === "$" ) {
 
           if ( statement.params.length && statement.params[0].string ) {
             var key = statement.params[0].string;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "jam": {
   	"name": "hbs",
   	"dependencies": {
-  	  "handlebars": null
+  	  "Handlebars": null
   	}
   }
 }


### PR DESCRIPTION
What's up with banana & democracy & expired milk??
quick note, I decided to change `handlerbar` -> `Handlebar` instead of changing the file name because I felt people are more likely to keep the original `Handlebar.js` they downloaded directly from Handlebar js website.

Please let me know how this works out.  ( apparently the mac is case in-sensitive.)
