### PR TITLE
Attempt att fix for loading argument-less block helpers:

### DIFF
--- a/demo/template/helpers/myhelper.js
+++ b/demo/template/helpers/myhelper.js
@@ -1,0 +1,8 @@
+define(["Handlebars"], function(Handlebars) {
+  function myhelper(options) {
+    return options.fn();
+  }
+
+  Handlebars.registerHelper("myhelper", myhelper);
+  return myhelper;
+});

--- a/demo/template/one.hbs
+++ b/demo/template/one.hbs
@@ -2,10 +2,17 @@
 {
   "name" : "one",
   "decription" : "A Demo Template",
-  "styles" : ["one"]
+  "styles" : ["one"],
+  "helpers": ["myhelper"]
 }
 }}
 <div class="best class ever">
+
+  {{#myhelper}}
+  Wow
+  {{else}}
+  Nope
+  {{/myhelper}}
 
   {{! Do a little bit of unecessary logic in here
   to show that it works with block helpers

--- a/hbs.js
+++ b/hbs.js
@@ -307,9 +307,23 @@ define([
                       meta = getMetaData( nodes ),
                       extDeps = getExternalDeps( nodes ),
                       vars = extDeps.vars,
-                      helps = extDeps.helpers || [],
+                      helps = (extDeps.helpers || []),
                       depStr = deps.join("', 'hbs!").replace(/_/g, '/'),
-                      helpDepStr = config.hbs && config.hbs.disableHelpers ?
+                      debugOutputStart = "",
+                      debugOutputEnd   = "",
+                      debugProperties = "",
+                      helpDepStr, metaObj, head, linkElem;
+
+                  if(meta !== "{}") {
+                    try {
+                      metaObj = JSON.parse(meta);
+                    } catch(e) {
+                      console.log("couldn't parse meta for %s", path);
+                    }
+                  }
+
+                  helps = helps.concat(metaObj.helpers || []);
+                  helpDepStr = config.hbs && config.hbs.disableHelpers ?
                       "" : (function (){
                         var i, paths = [],
                             pathGetter = config.hbs && config.hbs.helperPathCallback
@@ -320,11 +334,7 @@ define([
                           paths[i] = "'" + pathGetter(helps[i], path) + "'"
                         }
                         return paths;
-                      })().join(','),
-                      debugOutputStart = "",
-                      debugOutputEnd   = "",
-                      debugProperties = "",
-                      metaObj, head, linkElem;
+                      })().join(',');
 
                   if ( depStr ) {
                     depStr = ",'hbs!" + depStr + "'";
@@ -333,10 +343,9 @@ define([
                     helpDepStr = "," + helpDepStr;
                   }
 
-                  if ( meta !== "{}" ) {
+                  if (metaObj) {
                     try {
-                      metaObj = JSON.parse(meta);
-                      if ( metaObj && metaObj.styles ) {
+                      if (metaObj.styles) {
                         styleList = _.union(styleList, metaObj.styles);
 
                         // In dev mode in the browser


### PR DESCRIPTION
This is a proposed fix for #72

Adding the option to specify them in template meta data.

It seems, since handlebars itself can't tell the difference between
block helpers (or other helpers) without params, and just normal data,
that we need to work around this. Currently, the 'myhelper' wont get
loaded:

{{#myhelper}}
   Hell Yeah!
{{/myhelper}}

Because handlebars doesn't know if its a helper of shorthand for
{{#if myhelper}}{{/if}}

So let's just add the ability to specify helpers in the meta data,
so that we can tell that those needs to be loaded:
{{!
  {
    helpers: ["myhelper"]
  }
}}

Another option, i guess, could be to just attempt to load everything as helpers, and swallow errors. Though that feels, may i say, a little rough :)

Feedback welcome!
