### PR TITLE
Added a check for an empty dependency item. Was causing an error.

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -416,9 +416,8 @@ define([
                       text += "\r\n//@ sourceURL=" + path;
                   }
                   /*@end@*/
-
                   for ( var i in deps ) {
-                    if ( deps.hasOwnProperty(i) ) {
+                    if ( deps.hasOwnProperty(i) && deps[ i ].length !== 0 ) {
                       deps[ i ] = 'hbs!' + deps[ i ].replace(/_/g, '/');
                     }
                   }


### PR DESCRIPTION
When the array is empty, the replace method was causing an error. I don't know the root cause of the issue (why the array is empty) but checking this condition allows the program to continue.
