### PR TITLE
Reliable cross-domain template loading with MSIE >= v7 using XDomainRequest

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -86,7 +86,7 @@ define([
           var dom  = url.substr(uidx).split("/").shift();
           var msie = getIEVersion();
           var xdm  = ( dom != window.location.href.substr(hidx).split("/").shift() ) && (msie > -1);
-              xdm  = (msie >= 7) && (msie < 10);
+              xdm  = (msie >= 7);
           if( xdm )
           {
              var xdr = getXhr(true);


### PR DESCRIPTION
I updated the getXhr and fetchText functions to check for the domain you are on vs. the domain you are trying to load a template from.  It also checks to see if the browser is MSIE >= v7.

If you are on a different domain and using MSIE >= 7 browser, it will create, configure, and use XDomainRequest instead of XMLHttpRequest to load the template.  This works reliably in all aforementioned versions of MSIE.

Caveat: This will rely on the web server being configured with the proper Access-Control-Allow-Origin headers either through server configuration or script manipulation.
