### PR TITLE
Relative paths in defines() statements

### DIFF
--- a/demo/app.build.js
+++ b/demo/app.build.js
@@ -21,9 +21,9 @@
     paths: {
       "hbs": "../hbs",
       "Handlebars" : "../Handlebars",
-      "underscore" : "../hbs/underscore",
-      "i18nprecompile" : "../hbs/i18nprecompile",
-      "json2" : "../hbs/json2"
+      "hbs/underscore" : "../hbs/underscore",
+      "hbs/i18nprecompile" : "../hbs/i18nprecompile",
+      "hbs/json2" : "../hbs/json2"
       // if your project is already using underscore.js and you want to keep
       // the hbs plugin even after build (excludeHbs:false) you should set the
       // "hbs/underscore" path to point to the shared location like

--- a/hbs.js
+++ b/hbs.js
@@ -11,7 +11,7 @@
 define: false, process: false, window: false */
 define([
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)
-'./Handlebars', './hbs/underscore', './hbs/i18nprecompile', './hbs/json2'
+'Handlebars', 'hbs/underscore', 'hbs/i18nprecompile', 'hbs/json2'
 //>>excludeEnd('excludeHbs')
 ], function (
 //>>excludeStart('excludeHbs', pragmas.excludeHbs)

--- a/hbs/i18nprecompile.js
+++ b/hbs/i18nprecompile.js
@@ -1,5 +1,5 @@
 //>>excludeStart('excludeAfterBuild', pragmas.excludeAfterBuild)
-define(['../Handlebars', "./underscore"], function ( Handlebars, _ ) {
+define(['Handlebars', "hbs/underscore"], function ( Handlebars, _ ) {
 
   function replaceLocaleStrings ( ast, mapping, options ) {
     options = options || {};


### PR DESCRIPTION
This PR reverts relative paths introduced in 6a2cf647e6227e379fbdc1cb6d1262c6dffe7b40 back to non relative ones. Fixes #95.
