### PR TITLE
Remove removeCombined hack

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -445,10 +445,6 @@ define([
                       load(value);
                     });
                   }
-
-                  if ( config.removeCombined ) {
-                    fs.unlinkSync(path);
-                  }
               });
             }
 


### PR DESCRIPTION
@peol's hack to honor removeCombined — introduced in 6ad970557df3a77c8f4cb9a56d668c54745a8299 per #62 — is unsafe for projects that refer to the same template in multiple modules.

There are valid exceptions to the assumption that a template should only be used once in a build; for example, builds where cache optimization is balanced with optimizing the number of HTTP requests on initial page load.

jrburke/r.js#344 will address removeCombined support in a more robust way. Any objections to removing this hack and instead waiting for the removeFile API?