### PR TITLE
Fix 148 - cannot read property 'helper' of undefined

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -382,7 +382,7 @@ define([
             }
           }
 
-          helps = helps.concat(metaObj.helpers || []);
+          helps = helps.concat((metaObj && metaObj.helpers) ? metaObj.helpers : []);
           helpDepStr = config.hbs && config.hbs.disableHelpers ?
             '' : (function (){
               var i;


### PR DESCRIPTION
Fixes #148.

Checking that metaObj is not undefined.
