### PR TITLE
Fixed IE9 issue of hbs templates not getting rendered when the url was a relative URL.

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -89,13 +89,19 @@ define([
     };
 
     fetchText = function (url, callback) {
-      var uidx = (url.substr(0,5) === 'https') ? 8 : 7;
-      var hidx = (window.location.href.substr(0,5) === 'https') ? 8 : 7;
-      var dom = url.substr(uidx).split('/').shift();
-      var msie = getIEVersion();
-      var xdm = ( dom != window.location.href.substr(hidx).split('/').shift() ) && (msie > -1);
-
-      xdm = (msie >= 7);
+      var xdm = false;  
+      // If url is a fully qualified URL, it might be a cross domain request. Check for that.
+	  // IF url is a relative url, it cannot be cross domain.
+      if (url.indexOf('http') != 0 ){
+          xdm = false;
+      }else{
+          var uidx = (url.substr(0,5) === 'https') ? 8 : 7;
+          var hidx = (window.location.href.substr(0,5) === 'https') ? 8 : 7;
+          var dom = url.substr(uidx).split('/').shift();
+          var msie = getIEVersion();
+              xdm = ( dom != window.location.href.substr(hidx).split('/').shift() ) && (msie >= 7);
+      }
+      
       if ( xdm ) {
          var xdr = getXhr(true);
         xdr.open('GET', url);


### PR DESCRIPTION
fetchText was enhanced in a recent pull request to handle cross domain requests. But it misses the possibility that the URL can be a relative url. This becomes issue for IE9 in latest 0.5.0 labelled release. The templates do not get rendered as their cross domain request fails for the relative url

More details in code review comments added to [this commit](https://github.com/rkstar/require-handlebars-plugin/commit/e185bb6f2b71d6cf327f63d280019eb011f954df).

Let me know if you need any other information.
