### PR TITLE
Make getMetaData return valid JSON

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -233,7 +233,7 @@ define([
               return res;
             }
             catch (e) {
-              return '{ \'description\' : \'' + statement.comment + '\' }';
+              return '{ "description" : "' + statement.comment + '" }';
             }
           }
         }


### PR DESCRIPTION
The getMetaData function did not return valid JSON, if you ran the
returned string with `JSON.parse()` it would fail. Valid JSON uses double
quotes.
