### PR TITLE
Fix bug with multiple partials in a template

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -89,7 +89,7 @@ define([
     };
 
     fetchText = function (url, callback) {
-      var xdm = false;  
+      var xdm = false;
       // If url is a fully qualified URL, it might be a cross domain request. Check for that.
 	  // IF url is a relative url, it cannot be cross domain.
       if (url.indexOf('http') != 0 ){
@@ -101,7 +101,7 @@ define([
           var msie = getIEVersion();
               xdm = ( dom != window.location.href.substr(hidx).split('/').shift() ) && (msie >= 7);
       }
-      
+
       if ( xdm ) {
          var xdr = getXhr(true);
         xdr.open('GET', url);
@@ -418,7 +418,7 @@ define([
               var path;
               if(partialReference.match(/^(\.|\/)+/)) {
                 // relative path
-                path = cleanPath(baseDir + partialReference) 
+                path = cleanPath(baseDir + partialReference)
               }
               else {
                 // absolute path relative to config.hbs.partialsUrl if defined
@@ -437,7 +437,7 @@ define([
             }
           }
 
-          depStr = deps.join("', 'hbs!");
+          depStr = deps.join("', '");
 
           helps = helps.concat((metaObj && metaObj.helpers) ? metaObj.helpers : []);
           helpDepStr = disableHelpers ?
@@ -524,9 +524,9 @@ define([
 
           if(depStr) depStr = ", '"+depStr+"'";
 
-          var partialReferences = []; 
+          var partialReferences = [];
           if(require.config.hbs._partials[name])
-            partialReferences = require.config.hbs._partials[name].references; 
+            partialReferences = require.config.hbs._partials[name].references;
 
           text = '/* START_TEMPLATE */\n' +
                  'define('+tmplName+"['hbs','hbs/handlebars'"+depStr+helpDepStr+'], function( hbs, Handlebars ){ \n' +


### PR DESCRIPTION
This fixes #156.

Also includes some auto-whitespace cleanup from my text editor.
