### PR TITLE
Fix for “Error: TypeError: path must be a string”

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -91,7 +91,7 @@ define([
     fetchText = function (url, callback) {
       var xdm = false;
       // If url is a fully qualified URL, it might be a cross domain request. Check for that.
-	  // IF url is a relative url, it cannot be cross domain.
+      // IF url is a relative url, it cannot be cross domain.
       if (url.indexOf('http') != 0 ){
           xdm = false;
       }else{
@@ -106,7 +106,7 @@ define([
          var xdr = getXhr(true);
         xdr.open('GET', url);
         xdr.onload = function() {
-          callback(xdr.responseText);
+          callback(xdr.responseText, url);
         };
         xdr.onprogress = function(){};
         xdr.ontimeout = function(){};
@@ -122,7 +122,7 @@ define([
           //Do not explicitly handle errors, those should be
           //visible via console output in the browser.
           if (xhr.readyState === 4) {
-            callback(xhr.responseText);
+            callback(xhr.responseText, url);
           }
         };
         xhr.send(null);
@@ -141,7 +141,7 @@ define([
       var body = fs.readFileSync(path, 'utf8') || '';
       // we need to remove BOM stuff from the file content
       body = body.replace(/^\uFEFF/, '');
-      callback(body);
+      callback(body, path);
     };
   }
   else if (typeof java !== 'undefined' && typeof java.io !== 'undefined') {
@@ -155,7 +155,7 @@ define([
         text += new String(line) + '\n';
       }
       reader.close();
-      callback(text);
+      callback(text, path);
     };
   }
 
@@ -165,7 +165,7 @@ define([
       callback(cache[path]);
     }
     else {
-      fetchText(path, function(data){
+      fetchText(path, function(data, path){
         cache[path] = data;
         callback.call(this, data);
       });
@@ -385,7 +385,8 @@ define([
       };
 
       function fetchAndRegister(langMap) {
-        fetchText(path, function(text) {
+        var temp = path;
+          fetchText(path, function(text, path) {
           // for some reason it doesn't include hbs _first_ when i don't add it here...
           var nodes = Handlebars.parse(text);
           var partials = findPartialDeps( nodes );


### PR DESCRIPTION
Fix for “Error: TypeError: path must be a string” when using requirejs
(removedCombined = true) during compile
