### PR TITLE
Handle multiline comment in metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 demo-build/*
 .DS_STORE
+.idea/

--- a/hbs.js
+++ b/hbs.js
@@ -242,7 +242,9 @@ define([
               return res;
             }
             catch (e) {
-              return '{ "description" : "' + statement.comment + '" }';
+              return JSON.stringify({
+                description: res
+              });
             }
           }
         }
@@ -387,10 +389,10 @@ define([
 
       function fetchAndRegister(langMap) {
           fetchText(path, function(text, path) {
-			  
+
           var readCallback = (config.isBuild && config[onHbsReadMethod]) ? config[onHbsReadMethod]:  function(name,path,text){return text} ;
           // for some reason it doesn't include hbs _first_ when i don't add it here...
-          var nodes = Handlebars.parse( readCallback(name, path, text));				
+          var nodes = Handlebars.parse( readCallback(name, path, text));
           var partials = findPartialDeps( nodes );
           var meta = getMetaData( nodes );
           var extDeps = getExternalDeps( nodes );

--- a/tests/spec/multiline.js
+++ b/tests/spec/multiline.js
@@ -1,0 +1,27 @@
+define(['hbs!'+require.toUrl('tests/templates/multiline')], function(template) {
+
+  describe("Template with multiline comment and quotes", function() {
+
+    it("can load a template containing metadata with linebreaks and quotes", function() {
+      expect(template).to.be.a('function');
+    });
+
+    it("can parse metadata containing linebreaks", function() {
+      var meta = template.meta;
+      expect(meta).to.be.an('object');
+      var description = meta.description;
+      expect(description).to.be.a('string');
+      expect(description).to.contain('multiline comment');
+    });
+
+    it("can parse metadata containing quotes", function() {
+      var meta = template.meta;
+      expect(meta).to.be.an("object");
+      var description = meta.description;
+      expect(description).to.be.a('string');
+      expect(description).to.contain("\"quotes\"");
+    });
+
+  });
+
+});

--- a/tests/templates/multiline.hbs
+++ b/tests/templates/multiline.hbs
@@ -1,0 +1,6 @@
+{{!
+    This is a
+    multiline comment with "quotes"
+}}
+
+<div>This is a template with metadata containing linebreaks</div>


### PR DESCRIPTION
Hi!

We have a multiline leading comment in some of our templates, and they failed as the plugin tried to read it as metadata.

I haven't got the time at work to fight with the proxy in order to clone the repo, so I haven't been able to add  tests for this (used the website to edit the file).
If this is something your'e interested in merging, I'll do it properly with tests from home later. :smile: 

It's a really quick hack to make it work, so a cleanup-commit (again, if you're interested) is no problem before a merge
