### PR TITLE
When building using Java, read files as UTF-8

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -147,9 +147,9 @@ define([
   }
   else if (typeof java !== 'undefined' && typeof java.io !== 'undefined') {
     fetchText = function(path, callback) {
-      var f = new java.io.File(path);
-      var is = new java.io.FileReader(f);
-      var reader = new java.io.BufferedReader(is);
+      var fis = new java.io.FileInputStream(path);
+      var streamReader = new java.io.InputStreamReader(fis, "UTF-8");
+      var reader = new java.io.BufferedReader(streamReader);
       var line;
       var text = '';
       while ((line = reader.readLine()) !== null) {


### PR DESCRIPTION
When building on windows using Rhino (like RequireJS plugin with maven), the encoding of the files was wrong. FileReader reads a file using the system's default encoding.

This might be something that should be configurable, but the RequireJS-docs says that files should be in Unicode, so I'm thinking this is fine.

Concerning tests, I'm not sure if testing the the Java-side is relevant here?
