### PR TITLE
Register the partial itself, instead of just references to it

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -535,7 +535,8 @@ define([
 
           text = '/* START_TEMPLATE */\n' +
                  'define('+tmplName+"['hbs','hbs/handlebars'"+depStr+helpDepStr+'], function( hbs, Handlebars ){ \n' +
-                   'var t = Handlebars.template(' + prec + ');\n';
+                   'var t = Handlebars.template(' + prec + ');\n' +
+                   "Handlebars.registerPartial('" + name + "', t);\n";
 
           for(var i=0; i<partialReferences.length;i++)
             text += "Handlebars.registerPartial('" + partialReferences[i] + "', t);\n";

--- a/tests/spec/partial_loaded.js
+++ b/tests/spec/partial_loaded.js
@@ -1,0 +1,34 @@
+var templates = ['_partial_loaded'];
+
+templates = templates.map(function(template) {
+  return 'hbs!'+require.toUrl('tests/templates/'+template);
+});
+
+define([], function() {
+
+  require(['hbs!tests/templates/_partial_loaded'], function(partial) {
+
+    describe("Require reference to a partial", function() {
+
+      expect(partial).to.exist;
+    });
+  });
+
+  require(['hbs!' + require.toUrl('tests/templates/partial_loaded')], function(template) {
+    describe("template with an already loaded partial", function() {
+
+      it("loads the partials", function() {
+
+        var html = template({partialValue: "ha"});
+        var container = document.createElement('div');
+        container.innerHTML = html;
+        var bs = container.getElementsByTagName('b');
+        expect(bs).to.exist;
+        expect(bs.length).to.equal(1);
+        expect(bs[0].innerText).to.equal('Referenced ha');
+
+      });
+
+    });
+  });
+});

--- a/tests/templates/_partial_loaded.hbs
+++ b/tests/templates/_partial_loaded.hbs
@@ -1,0 +1,1 @@
+<b>Referenced {{partialValue}}</b>

--- a/tests/templates/partial_loaded.hbs
+++ b/tests/templates/partial_loaded.hbs
@@ -1,0 +1,1 @@
+<div>Template that loads a referenced partial {{> tests/templates/_partial_loaded}}</div>


### PR DESCRIPTION
- Issues arose when attempting to reference a partial that was already
  listed in an AMD dependency list.
- Fixes #169
