### PR TITLE
fixed typo in license

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -1,5 +1,5 @@
 /**
- * @license Handlebars hbs 0.4.0 - Alex Sexton, but Handlebars has it's own licensing junk
+ * @license Handlebars hbs 0.4.0 - Alex Sexton, but Handlebars has its own licensing junk
  *
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/require-cs for details on the plugin this was based off of


### PR DESCRIPTION
its => belonging to it
it's => it is / it has
