### PR TITLE
Support subexpressions in helper parameters and hash pairs

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -304,8 +304,32 @@ define([
                   || param instanceof Handlebars.AST.StringNode
                   || param instanceof Handlebars.AST.IntegerNode
                   || param instanceof Handlebars.AST.BooleanNode
+                  || param instanceof Handlebars.AST.SexprNode
                 ) {
                   helpersres.push(statement.id.string);
+
+                  // Look into the params to find subexpressions
+                  if (typeof statement.params !== 'undefined') {
+                      _(statement.params).forEach(function(param) {
+                        if (param.type === 'sexpr' && param.isHelper === true) {
+                          // Found subexpression in params
+                          helpersres.push(param.id.string);
+                        }
+                      });
+                  }
+
+                  // Look in the hash to find sub expressions
+                  if (typeof statement.hash !== 'undefined' && typeof statement.hash.pairs !== 'undefined') {
+                    _(statement.hash.pairs).forEach(function(pair) {
+                      var pairName = pair[0],
+                          pairValue = pair[1];
+                      if (pairValue.type === 'sexpr' && pairValue.isHelper === true) {
+                        // Found subexpression in hash params
+                        helpersres.push(pairValue.id.string);
+                      }
+                    });
+                  }
+
                 }
 
                 parts = composeParts( param.parts );

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -20,7 +20,8 @@ module.exports = function(config) {
       {pattern: 'hbs/*.js', included: false},
       {pattern: 'tests/*.js', included: false},
       {pattern: 'tests/spec/*.js', included: false},
-      {pattern: 'tests/templates/**/*.hbs', included: false}
+      {pattern: 'tests/templates/**/*.hbs', included: false},
+      {pattern: 'tests/templates/helpers/*.js', included: false}
     ],
 
 

--- a/tests/spec/helpers.js
+++ b/tests/spec/helpers.js
@@ -1,0 +1,16 @@
+define(['hbs!'+require.toUrl('tests/templates/helpers')], function(template) {
+
+  describe("Helpers embedded in a template", function() {
+
+    it("can be rendered", function() {
+      expect(typeof template).to.equal('function');
+      var html = template({hello: 'world'});
+      var container = document.createElement('div');
+      container.innerHTML=html;
+      var text = container.innerText.trim();
+      expect(text).to.equal('This is a very simple template )foo(');
+    });
+
+  });
+
+});

--- a/tests/spec/sexpr_hash.js
+++ b/tests/spec/sexpr_hash.js
@@ -1,0 +1,16 @@
+define(['hbs!'+require.toUrl('tests/templates/sexpr_hash')], function(template) {
+
+  describe("Subexpression handled in helpers", function() {
+
+    it("can render subexpressions in helpers", function() {
+      expect(typeof template).to.equal('function');
+      var html = template({hello: 'world'});
+      var container = document.createElement('div');
+      container.innerHTML=html;
+      var text = container.innerText.trim();
+      expect(text).to.equal('Testing sexpr in helper hash Foo (Bar) Baz');
+    });
+
+  });
+
+});

--- a/tests/spec/sexpr_param.js
+++ b/tests/spec/sexpr_param.js
@@ -1,0 +1,16 @@
+define(['hbs!'+require.toUrl('tests/templates/sexpr_params')], function(template) {
+
+  describe("Subexpression handled in helpers", function() {
+
+    it("can render subexpressions in helpers", function() {
+      expect(typeof template).to.equal('function');
+      var html = template({hello: 'world'});
+      var container = document.createElement('div');
+      container.innerHTML=html;
+      var text = container.innerText.trim();
+      expect(text).to.equal('Testing sexpr in helper params )(foo)(');
+    });
+
+  });
+
+});

--- a/tests/templates/helpers.hbs
+++ b/tests/templates/helpers.hbs
@@ -1,0 +1,1 @@
+<div> This is a very simple template {{outer-helper "foo"}}</div>

--- a/tests/templates/helpers/inner-helper.js
+++ b/tests/templates/helpers/inner-helper.js
@@ -1,0 +1,17 @@
+define([
+    'hbs/handlebars'
+], function(Handlebars) {
+
+    'use strict';
+
+    function innerHelper(key) {
+        if (typeof key !== 'undefined') {
+            return '(' + key + ')';
+        }
+        return '(missing)';
+    }
+
+    Handlebars.registerHelper('inner-helper', innerHelper);
+
+    return innerHelper;
+});

--- a/tests/templates/helpers/outer-helper.js
+++ b/tests/templates/helpers/outer-helper.js
@@ -1,0 +1,17 @@
+define([
+    'hbs/handlebars'
+], function(Handlebars) {
+
+    'use strict';
+
+    function outerHelper(key) {
+        if (typeof key !== 'undefined') {
+            return ')' + key + '(';
+        }
+        return ')missing(';
+    }
+
+    Handlebars.registerHelper('outer-helper', outerHelper);
+
+    return outerHelper;
+});

--- a/tests/templates/helpers/var-sub.js
+++ b/tests/templates/helpers/var-sub.js
@@ -1,0 +1,30 @@
+define([
+    'hbs/handlebars'
+], function(Handlebars) {
+
+    'use strict';
+
+    function varSub(key, options) {
+        
+        var value,
+            keyName,
+            prop;
+
+        for (prop in options.hash) {
+            if (options.hash.hasOwnProperty(prop)) {
+                value = options.hash[prop];
+                keyName = '{' + prop + '}';
+                if (key.indexOf(keyName) !== -1) {
+                    // Argument found in key
+                    key = key.replace(keyName, value);
+                }
+            }
+        }
+        return key;
+
+    }
+
+    Handlebars.registerHelper('var-sub', varSub);
+
+    return varSub;
+});

--- a/tests/templates/sexpr_hash.hbs
+++ b/tests/templates/sexpr_hash.hbs
@@ -1,0 +1,1 @@
+<div> Testing sexpr in helper hash {{var-sub "Foo {VAR1} Baz" VAR1=(inner-helper "Bar")}}</div>

--- a/tests/templates/sexpr_params.hbs
+++ b/tests/templates/sexpr_params.hbs
@@ -1,0 +1,1 @@
+<div> Testing sexpr in helper params {{outer-helper (inner-helper "foo")}}</div>

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -15,6 +15,12 @@ requirejs.config({
     // ask Require.js to load these files (all our tests)
     deps: tests,
 
+    hbs: {
+      helperPathCallback: function (name) {
+        return '/base/tests/templates/helpers/' + name + '.js';
+      }
+    },
+
     // start test run, once Require.js is done
     callback: window.__karma__.start
 });


### PR DESCRIPTION
This PR should provide some if not full support for subexpressions in helpers.

Related to issue #172.
