### PR TITLE
Support partials with lodash.

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -232,7 +232,7 @@ define([
         if ( nodes && nodes.statements ) {
           res = recursiveNodeSearch( nodes.statements, [] );
         }
-        return _(res).unique();
+        return _.unique(res);
       }
 
       // See if the first item is a comment that's json


### PR DESCRIPTION
When using lodash.js (or lodash.compat.js) instead of underscore.js, partials do not work.  This is due to a single line in findPartialDeps that returns a lodashWrapper instead of an array.  A simple change to the invocation of unique() fixes the problem in lodash and continues to work in underscore.

I understand that lodash.underscore.js can be used as a drop-in replacement for underscore.js and will work around the issue, but we are locked into using lodash.compat in our environment and this is the first issue we've run into while using it as a substitute for underscore.
