### PR TITLE
Added support for using @index parameter for a helper in an #each block....

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -309,6 +309,7 @@ define([
                   || param instanceof Handlebars.AST.StringNode
                   || param instanceof Handlebars.AST.IntegerNode
                   || param instanceof Handlebars.AST.BooleanNode
+                  || param instanceof Handlebars.AST.DataNode
                   || param instanceof Handlebars.AST.SexprNode
                 ) {
                   helpersres.push(statement.id.string);


### PR DESCRIPTION
...  The parameter is a AST.DataNode with no 'parts' field.
