### PR TITLE
Update hbs.js

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -597,7 +597,7 @@ define([
           //sourceURL trick, so skip it if enabled.
           /*@if (@_jscript) @else @*/
           if (!config.isBuild) {
-            text += '\r\n//@ sourceURL=' + path;
+            text += '\r\n//# sourceURL=' + path;
           }
           /*@end@*/
 


### PR DESCRIPTION
According to the sourcemap proposal //# is prefered over //@.
Also there is a problem in IE10: http://stackoverflow.com/questions/20988801/getting-errors-in-ie8-and-ie9-only-not-in-other-browsers which is fixed by this change.
