### PR TITLE
Update NPM dependencies, and add a David-badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 demo-build/*
 .DS_STORE
 .idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Handlebars : `v1.3.0`
 
 hbs.js     : `v0.8.1`
 
+[![devDependency Status](https://david-dm.org/SlexAxton/require-handlebars-plugin/dev-status.svg)](https://david-dm.org/SlexAxton/require-handlebars-plugin#info=devDependencies)
+
 ## Requirements
 
 Should work in both the java and node build environments.

--- a/package.json
+++ b/package.json
@@ -16,31 +16,31 @@
     }
   },
   "jam": {
-  	"name": "hbs",
-  	"dependencies": {
-  	  "Handlebars": null
-  	}
+    "name": "hbs",
+    "dependencies": {
+      "Handlebars": null
+    }
   },
   "scripts": {
-    "test":"node_modules/karma/bin/karma start --singleRun"
+    "test": "node_modules/karma/bin/karma start --singleRun"
   },
   "contributors": [
     "Xavier Damman <xdamman@gmail.com>"
   ],
   "devDependencies": {
-    "karma-script-launcher": "~0.1.0",
-    "karma-chrome-launcher": "~0.1.1",
+    "karma": "~0.12.23",
+    "karma-cajon": "0.0.1",
+    "karma-chai": "~0.1.0",
+    "karma-chrome-launcher": "~0.1.4",
+    "karma-coffee-preprocessor": "~0.2.1",
+    "karma-firefox-launcher": "~0.1.3",
     "karma-html2js-preprocessor": "~0.1.0",
-    "karma-firefox-launcher": "~0.1.2",
-    "karma-jasmine": "~0.1.4",
-    "requirejs": "~2.1.9",
-    "karma-requirejs": "~0.2.0",
-    "karma-coffee-preprocessor": "~0.1.1",
-    "karma-phantomjs-launcher": "~0.1.1",
-    "karma": "~0.10.8",
-    "mocha": "~1.15.1",
-    "karma-mocha": "~0.1.1",
-    "karma-chai": "0.0.2",
-    "karma-cajon": "0.0.1"
+    "karma-jasmine": "~0.1.5",
+    "karma-mocha": "~0.1.9",
+    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-requirejs": "~0.2.2",
+    "karma-script-launcher": "~0.1.0",
+    "mocha": "~1.21.4",
+    "requirejs": "~2.1.15"
   }
 }


### PR DESCRIPTION
It wouldn't build using `npm install` beacuse of some peerDependency or some such, so I updated them.

BTW, any interest in a Grunt-based build instead of the .sh script? Maybe getting your dependencies via bower/npm instead of bundling them?

Another thing, are all the dependencies in use? Seems to be quite a lot of them for a relatively small project. In this PR I just did a `npm install --save-dev` for each of your existing dependencies. At least the karma launchers except for chrome are not in use, etc.
