### PR TITLE
checking paths before removing

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -626,7 +626,9 @@ define([
           }
 
           if ( config.removeCombined && path ) {
-            fs.unlinkSync(path);
+            if (fs && fs.existsSync(path)) {
+              fs.unlinkSync(path);
+            }
           }
 
         });


### PR DESCRIPTION
wrapping fs.unlinkSync in a check to make sure the path exists before trying to remove it

fixes: #205 - Problems with partials and hbs not finding them
