### PR TITLE
Always declare templates with hbs!

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -568,7 +568,7 @@ define([
           var configHbs = config.hbs || {};
           var options = _.extend(configHbs.compileOptions || {}, { originalKeyFallback: configHbs.originalKeyFallback });
           var prec = precompile( text, mapping, options);
-          var tmplName = config.isBuild ? '' : "'" + name + "',";
+          var tmplName = config.isBuild ? '' : "'hbs!" + name + "',";
 
           if(depStr) depStr = ", '"+depStr+"'";
 


### PR DESCRIPTION
Without this change it is impossible to have module.js right next to module.hbs because the names collide. This ensures that hbs! is always added to the module name, stopping the collision.
