### PR TITLE
use the module name, including hbs! in builds

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -568,7 +568,7 @@ define([
           var configHbs = config.hbs || {};
           var options = _.extend(configHbs.compileOptions || {}, { originalKeyFallback: configHbs.originalKeyFallback });
           var prec = precompile( text, mapping, options);
-          var tmplName = config.isBuild ? '' : "'hbs!" + name + "',";
+          var tmplName = "'hbs!" + name + "',";
 
           if(depStr) depStr = ", '"+depStr+"'";
 


### PR DESCRIPTION
Sorry about making two PRs, should have tried a build before doing the first one.

Without this the callback never fires when using relative paths.
