### PR TITLE
Fixed: removeCombined breaks the build with multiple modules

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -92,7 +92,7 @@ define([
     fetchText = function (url, callback) {
       var xdm = false;
       // If url is a fully qualified URL, it might be a cross domain request. Check for that.
-	  // IF url is a relative url, it cannot be cross domain.
+      // IF url is a relative url, it cannot be cross domain.
       if (url.indexOf('http') != 0 ){
           xdm = false;
       }else{
@@ -176,6 +176,9 @@ define([
   var styleMap = {};
   //>>excludeEnd('excludeHbs')
 
+  var config;
+  var filesToRemove = [];
+
   return {
 
     get: function () {
@@ -191,8 +194,9 @@ define([
 
     version: '2.0.0',
 
-    load: function (name, parentRequire, load, config) {
+    load: function (name, parentRequire, load, _config) {
       //>>excludeStart('excludeHbs', pragmas.excludeHbs)
+      config = config || _config;
 
       var compiledName = name + customNameExtension;
       config.hbs = config.hbs || {};
@@ -630,9 +634,7 @@ define([
           }
 
           if ( config.removeCombined && path ) {
-            if (fs && fs.existsSync(path)) {
-              fs.unlinkSync(path);
-            }
+            filesToRemove.push(path);
           }
 
         });
@@ -673,6 +675,16 @@ define([
         }
       }
       //>>excludeEnd('excludeHbs')
+    },
+
+    onLayerEnd: function () {
+      if (config.removeCombined && fs) {
+        filesToRemove.forEach(function (path) {
+          if (fs.existsSync(path)) {
+            fs.unlinkSync(path);
+          }
+        });
+      }
     }
   };
 });


### PR DESCRIPTION
I'm trying to build multiple applications and a shared library into a set of files, with one file per app and one file for shared code.  `removeCombined` option is enabled. The example below for simplicity has two modules.

```
root/
  src/
    foo.js
    bar.js
    template.hbs
config.js
```

**src/foo.js**:

``` javascript
define(function (require) {
  require('bar');
});
```

**src/bar.js**:

``` javascript
define(function (require) {
  require('hbs!./template');
});
```

**src/template.hbs**

``` handlebars
<div></div>
```

**config.js**:

``` javascript
({
  paths: {
    hbs: '../bower_components/require-handlebars-plugin/hbs'
  },
  appDir: 'src',
  baseUrl: './',
  dir: 'build/src',
  removeCombined: true,
  modules: [
    {
      name: 'foo',
      exclude: [ 'bar' ]
    },
    {
      name: 'bar'
    }
  ]
})
```

However, combined templates are removed too early. I'm getting the following error:

```
$ r.js -o config.js

Tracing dependencies for: foo

Tracing dependencies for: bar
Error: ENOENT, no such file or directory '/Users/dremora/Code/playground/require-handlebars-plugin-bug/build/src/template.hbs'
In module tree:
    bar
      hbs

Error: Error: ENOENT, no such file or directory '/Users/dremora/Code/playground/require-handlebars-plugin-bug/build/src/template.hbs'
In module tree:
    bar
      hbs

    at Object.fs.openSync (fs.js:438:18)
```

See also [this gist](https://gist.github.com/Dremora/3c4b0bcd3126803780c1) (checkout, run `bower install && r.js -o config.js`).

This pull request fixes the issue.
