### PR TITLE
Allow users to configure hbs to use handlebars in an alternate location

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -562,8 +562,10 @@ define([
           if(config.hbs._partials[name])
             partialReferences = config.hbs._partials[name].references;
 
+          var handlebarsPath = (config.hbs && config.hbs.handlebarsPath) ? config.hbs.handlebarsPath : 'hbs/handlebars';
+
           text = '/* START_TEMPLATE */\n' +
-                 'define('+tmplName+"['hbs','hbs/handlebars'"+depStr+helpDepStr+'], function( hbs, Handlebars ){ \n' +
+                 'define('+tmplName+"['hbs','"+handlebarsPath+"'"+depStr+helpDepStr+'], function( hbs, Handlebars ){ \n' +          
                    'var t = Handlebars.template(' + prec + ');\n' +
                    "Handlebars.registerPartial('" + name + "', t);\n";
 


### PR DESCRIPTION
For apps that currently have handlebars defined in a location other than
an hbs directory at the root of the project, this will allow them to
ensure that hbs uses the handlebars they need. (example usage below)

The key here is that when you try to bring in handlebars more than once,
things seem to become very broken. You either end up with modules using
handlebars instance A where the helper was registered on instance B, or
the modules are using the shorthand "handlebars" and hbs is using the
specified path "hbs/handlebars" and then require.js gets confused.
Therefore, this new config option allows a project with many modules
already using the shorthand to stay the same, instead of having to change
each one of them to start using the same path that hbs is using.

```javascript
require.config({
    paths: {
        "handlebars": "some/path/to/handlebars" // shorthand
	}
...
```

Example usage:

```javascript
"hbs": {
    "handlebarsPath": "handlebars",
    "helperDirectory": "some/path/for/templates/helpers/"
}
```