### PR TITLE
BUG IE8 - Wrap `forEach` with underscore.

### DIFF
--- a/hbs.js
+++ b/hbs.js
@@ -318,7 +318,7 @@ define([
         }
 
         if(statement && statement.params){
-          statement.params.forEach(function (param) {
+          _(statement.params).forEach(function (param) {
             checkStatementForHelpers(param, helpersres);
           });
         }
@@ -653,7 +653,7 @@ define([
 
     onLayerEnd: function () {
       if (config.removeCombined && fs) {
-        filesToRemove.forEach(function (path) {
+        _(filesToRemove).forEach(function (path) {
           if (fs.existsSync(path)) {
             fs.unlinkSync(path);
           }


### PR DESCRIPTION
L321 breaks when in "dev mode" in IE8 for lack of wrapping `.forEach` with the `_` version with this error:

```
msg: Object doesn't support this property or method
file: http://10.0.2.2:3001/node_modules/require-handlebars-plugin/hbs.js
line: 321
col: undefined
error: undefined
```

I also added the wrap on L656 for consistency, although that looks to be server-side...
