### PR TITLE
Correct the README in regards to helpers (versus disableHelpers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,8 +229,8 @@ require.config({
 
   // hbs config
   hbs: {
-    disableHelpers: true,         // When true, won't look for and try to automatically load
-                                  // helpers (false by default)
+    helpers: false,               // When false, won't look for and try to automatically load
+                                  // helpers (true by default)
 
     helperPathCallback:           // Callback to determine the path to look for helpers
       function (name) {           // ('/templates/helpers/'+name by default)


### PR DESCRIPTION
It looks like this documentation has been incorrect for some time now.

The var in the code is disableHelpers, but it gets set using config.hbs.helpers
(not config.hbs.disableHelpers)